### PR TITLE
Remove unneeded "finished" signal in QThread

### DIFF
--- a/dangerzone/gui/main_window.py
+++ b/dangerzone/gui/main_window.py
@@ -486,7 +486,6 @@ class SettingsWidget(QtWidgets.QWidget):
 
 
 class ConvertThread(QtCore.QThread):
-    is_finished = QtCore.Signal(bool)
     update = QtCore.Signal(bool, str, int)
 
     def __init__(self, global_common, common):
@@ -503,13 +502,12 @@ class ConvertThread(QtCore.QThread):
         else:
             ocr_lang = None
 
-        if convert(
+        convert(
             self.common.input_filename,
             self.common.output_filename,
             ocr_lang,
             self.stdout_callback,
-        ):
-            self.is_finished.emit(self.error)
+        )
 
     def stdout_callback(self, line):
         try:


### PR DESCRIPTION
Quoting @deeplow:

> QThread already sends a "finished" signal when it ends. This also
solves a previously introduced bug where the signal had a signature
of one bool argument representing if there was an error or not.
>
> This arg's inclusion was introduced in commit ea47a2e92ce957f0f9e104290bc433f047dddd99
but seems it was added by mistake as the slot that catches the
signal (ConvertWidget.all_done) doesn't have any arguments.
>
> This last part in particular was introducing an error in Qt6
since the signal became a private signal, whereas Qt 5 had
defined it as a just a signal [1].

[1]: https://github.com/freedomofpress/dangerzone/pull/164#discussion_r896373680